### PR TITLE
Fix: 할 일 생성 후 카테고리를 잘못 조회하는 버그 수정

### DIFF
--- a/feature/backlog/src/main/java/com/poptato/backlog/BacklogViewModel.kt
+++ b/feature/backlog/src/main/java/com/poptato/backlog/BacklogViewModel.kt
@@ -218,7 +218,7 @@ class BacklogViewModel @Inject constructor(
         }
         updateList(updatedList)
 
-        getBacklogList(categoryId = -1, page = 0, size = uiState.value.backlogList.size)
+        getBacklogList(categoryId = uiState.value.selectedCategoryId, page = 0, size = 100)
     }
 
     private fun onFailedUpdateBacklogList() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,4 +23,4 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.enableJetifier=true
 version=1.1.3
-version_code=7
+version_code=8

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,5 +22,5 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 android.enableJetifier=true
-version=1.1.2
-version_code=6
+version=1.1.3
+version_code=7


### PR DESCRIPTION
## 이슈 번호
> 작업이 완료된 이슈의 번호를 기록해주세요.

## 작업내용
> 작업한 내용을 설명해주세요. 왜 수정했는지? 무엇을 구현했는지? 등등

- [x] 할 일 생성 후 카테고리를 잘못 조회하는 버그 수정

## 결과물
> 구현한 것 스크린샷 또는 영상 또는 gif 형태로 올려주세요.

## 리뷰어에게 추가로 요구하는 사항(선택)
> 이 부분을 자세히 봐야한다 또는 함수 로직에 확신이 없는데 더 좋은 방법이 있을까요? 등등
